### PR TITLE
add dmx_source enum and ioctl

### DIFF
--- a/dvb.c
+++ b/dvb.c
@@ -35,7 +35,6 @@
 #include <sys/ioctl.h>
 #include <net/if.h>
 #include <linux/dvb/frontend.h>
-#include <linux/dvb/dmx.h>
 #include <fcntl.h>
 #include <ctype.h>
 #include "dvb.h"

--- a/dvb.h
+++ b/dvb.h
@@ -2,6 +2,7 @@
 #define DVB_H
 #include <linux/dvb/frontend.h>
 #include <linux/dvb/version.h>
+#include <linux/dvb/dmx.h>
 
 #define DVBAPIVERSION (DVB_API_VERSION << 8 | DVB_API_VERSION_MINOR)
 #if DVBAPIVERSION < 0x0500
@@ -38,6 +39,24 @@
 #define MAX_FRQ_DVBC  860000
 #define MIN_FRQ_DVBS  950000
 #define MAX_FRQ_DVBS 2150000
+
+#ifndef DMX_SET_SOURCE
+/**
+ * DMX_SET_SOURCE and dmx_source enum removed on 4.14 kernel
+ * Check commit 13adefbe9e566c6db91579e4ce17f1e5193d6f2c
+**/
+enum dmx_source {
+	DMX_SOURCE_FRONT0 = 0,
+	DMX_SOURCE_FRONT1,
+	DMX_SOURCE_FRONT2,
+	DMX_SOURCE_FRONT3,
+	DMX_SOURCE_DVR0   = 16,
+	DMX_SOURCE_DVR1,
+	DMX_SOURCE_DVR2,
+	DMX_SOURCE_DVR3
+};
+#define DMX_SET_SOURCE _IOW('o', 49, enum dmx_source)
+#endif
 
 typedef struct struct_transponder
 {


### PR DESCRIPTION
That commits bring back dmx_source ioctl and enumertion required by minisatip.
DMX_SET_SOURCE and dmx_source enum removed on 4.14 kernel.
Check commit 13adefbe9e566c6db91579e4ce17f1e5193d6f2c